### PR TITLE
Change gitignore to work in subdirectories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,10 @@
-/*.egg-info/
-/build/
-/dist/
-/__pycache__/
+# Python
+*.egg-info/
+build/
+dist/
+__pycache__/
 *.pyc
+venv/
+
+# LibreOffice
+.~lock.*


### PR DESCRIPTION
Starting the line with forward slash limits the pattern to only root directory. I noticed because `__pycache__/` in `/theory-dev/wrk/przedrostki` wasn't ignored.

Additionally, `venv/` added to allow keeping a virtualenv there.